### PR TITLE
Tune the live boot support.

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -114,6 +114,13 @@ endif
 
 ifeq ($(KERNELFLINGER_SUPPORT_USB_STORAGE),true)
     KERNELFLINGER_CFLAGS += -DUSB_STORAGE
+    ifeq ($(KERNELFLINGER_SUPPORT_LIVE_BOOT),true)
+        ifneq ($(TARGET_BUILD_VARIANT),user)
+            KERNELFLINGER_CFLAGS += -DLIVE_BOOT
+        else
+            $(warning Live boot is only supported in eng and userdebug build)
+        endif
+    endif
 endif
 
 ifeq ($(KERNELFLINGER_USE_RPMB),true)

--- a/avb/libavb/uefi_avb_ops.c
+++ b/avb/libavb/uefi_avb_ops.c
@@ -235,13 +235,17 @@ static AvbIOResult read_rollback_index(__attribute__((unused)) AvbOps* ops,
   if (out_rollback_index == NULL)
     return ret;
 
+  if (is_live_boot())
+    ret = EFI_NOT_FOUND;
+  else {
 #if defined(SECURE_STORAGE_EFIVAR)
-  ret = read_efi_rollback_index(rollback_index_slot, out_rollback_index);
+    ret = read_efi_rollback_index(rollback_index_slot, out_rollback_index);
 #elif defined(SECURE_STORAGE_RPMB)
-  ret = read_rpmb_rollback_index(rollback_index_slot, out_rollback_index);
+    ret = read_rpmb_rollback_index(rollback_index_slot, out_rollback_index);
 #else
   *out_rollback_index = 0;
 #endif
+  }
 
   if (ret == EFI_NOT_FOUND) {
     *out_rollback_index = 0;
@@ -263,11 +267,15 @@ static AvbIOResult write_rollback_index(__attribute__((unused)) AvbOps* ops,
   if (rollback_index == 0)
     return ret;
 
+  if (is_live_boot())
+    ret = EFI_SUCCESS;
+  else {
 #if defined(SECURE_STORAGE_EFIVAR)
-  ret = write_efi_rollback_index(rollback_index_slot, rollback_index);
+    ret = write_efi_rollback_index(rollback_index_slot, rollback_index);
 #elif defined(SECURE_STORAGE_RPMB)
-  ret = write_rpmb_rollback_index(rollback_index_slot, rollback_index);
+    ret = write_rpmb_rollback_index(rollback_index_slot, rollback_index);
 #endif
+  }
   if (EFI_ERROR(ret)) {
     efi_perror(ret, L"Couldn't write rollback index");
     return AVB_IO_RESULT_ERROR_IO;

--- a/include/libkernelflinger/storage.h
+++ b/include/libkernelflinger/storage.h
@@ -88,7 +88,7 @@ EFI_STATUS fill_with(EFI_BLOCK_IO *bio, EFI_LBA start, EFI_LBA end,
 EFI_STATUS fill_zero(EFI_BLOCK_IO *bio, EFI_LBA start, EFI_LBA end);
 BOOLEAN is_cur_storage_ufs(void);
 EFI_STATUS get_logical_block_size(UINTN *logical_blk_size);
-BOOLEAN is_boot_device_removable(void);
+BOOLEAN is_live_boot(void);
 BOOLEAN is_boot_device_virtual(void);
 EFI_STATUS set_logical_unit(UINT64 user_lun, UINT64 factory_lun);
 void print_progress(EFI_LBA done, EFI_LBA total, uint32_t sec, uint32_t *prev_sec, uint32_t *prev);

--- a/kernelflinger.c
+++ b/kernelflinger.c
@@ -1357,7 +1357,7 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table)
 			BOOTLOADER_FILE, BOOTLOADER_FILE_BAK, KFSELF_FILE, KFBACKUP_FILE);
 
 #ifdef USE_TPM
-	if (!is_boot_device_removable()) {
+	if (!is_live_boot()) {
 		ret = tpm2_init();
 		if (EFI_ERROR(ret)) {
 			efi_perror(ret, L"Failed to init TPM, enter fastboot mode");
@@ -1431,7 +1431,11 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table)
 #ifdef USERDEBUG
 	debug(L"checking device state");
 
-	if (device_is_unlocked()) {
+	if (is_live_boot()) {
+		boot_state = BOOT_STATE_ORANGE;
+		lock_prompted = TRUE;
+		boot_error(LIVE_BOOT_CODE, boot_state, NULL, 0);
+	} else if (device_is_unlocked()) {
 		boot_state = BOOT_STATE_ORANGE;
 		debug(L"Device is unlocked");
 	} else if (!is_platform_secure_boot_enabled() && !device_is_provisioning()) {

--- a/libfastboot/fastboot_oem.c
+++ b/libfastboot/fastboot_oem.c
@@ -410,7 +410,7 @@ static void cmd_oem_set_storage(INTN argc, CHAR8 **argv)
 	set_device_security_info(NULL);
 
 #ifdef USE_TPM
-	if (!is_boot_device_removable())
+	if (!is_live_boot())
 		tpm2_init();
 #endif
 

--- a/libkernelflinger/rpmb/rpmb_storage.c
+++ b/libkernelflinger/rpmb/rpmb_storage.c
@@ -760,8 +760,8 @@ EFI_STATUS rpmb_storage_init(void)
 	BOOLEAN real = FALSE;
 
 #ifndef RPMB_SIMULATE
-	if (!is_boot_device_removable()) {
-		// For removable storage, such as USB disk, always use simulate RPMB.
+	if (!is_live_boot()) {
+		// For USB live boot case, always use simulate RPMB.
 		// For virtual storage, always use real rpmb interface but the decision to
 		// use simulate or physical are in device module side not in android osloader.
 		// For other cases, Check life cycle and secure boot.

--- a/libkernelflinger/security_efi.c
+++ b/libkernelflinger/security_efi.c
@@ -101,8 +101,8 @@ EFI_STATUS set_device_security_info(__attribute__((unused)) IN void *security_da
 	UINT8 i;
 
 	// Set the fixed RPMB key
-	if (is_boot_device_removable()) {
-		// For removable storage, such as USB disk, always use one fixed RPMB key.
+	if (is_live_boot()) {
+		// For USB live boot case, always use one fixed RPMB key.
 		return set_rpmb_derived_key(fixed_rpmb_keys, RPMB_KEY_SIZE, 1);
 	}
 
@@ -209,7 +209,7 @@ EFI_STATUS get_seeds(IN UINT32 *num_seeds, OUT VOID *seed_list)
 	}
 
 #ifdef USE_TPM
-	if (!is_boot_device_removable()) {
+	if (!is_live_boot()) {
 		ret = tpm2_read_trusty_seed(seed);
 		if (EFI_ERROR(ret)) {
 			efi_perror(ret, L"Failed to read trusty seed from TPM");

--- a/libkernelflinger/storage.c
+++ b/libkernelflinger/storage.c
@@ -551,9 +551,9 @@ notfound:
 	return EFI_SUCCESS;
 }
 
-BOOLEAN is_boot_device_removable(void)
+BOOLEAN is_live_boot(void)
 {
-#ifdef USB_STORAGE
+#ifdef LIVE_BOOT
 	return cur_storage == &STORAGE(STORAGE_USB);
 #else
 	return FALSE;

--- a/ux.c
+++ b/ux.c
@@ -122,6 +122,17 @@ static const ui_textline_t not_bootable_message[] = {
 #endif
 	{ NULL, NULL, FALSE }
 };
+
+static const ui_textline_t live_boot_message[] = {
+	{ &COLOR_LIGHTRED,	"WARNING:",				TRUE },
+	{ &COLOR_LIGHTGRAY,	"Live boot is used for debug purpose.",	FALSE },
+	{ &COLOR_LIGHTGRAY,	"",					FALSE },
+	{ &COLOR_LIGHTGRAY,	"Your device is in a unlocked state",	FALSE },
+	{ &COLOR_LIGHTGRAY,	"due to live boot.",			FALSE },
+	{ &COLOR_LIGHTGRAY,	"Lock/unlcok state will not be saved.",	FALSE },
+	{ NULL, NULL, FALSE }
+};
+
 #ifdef CRASHMODE_USE_ADB
 static const ui_textline_t adb_message[] = {
 	{ &COLOR_LIGHTGRAY,	"",						FALSE },
@@ -155,7 +166,8 @@ static const struct ux_prompt {
 	[SECURE_BOOT_CODE]		=	{ &COLOR_ORANGE,	secure_boot_off },
 	[BOOTIMAGE_UNTRUSTED_CODE]	=	{ &COLOR_YELLOW,	device_untrusted_bootimage},
 	[CRASH_EVENT_CODE]		=	{ &COLOR_LIGHTRED,	crash_event_message},
-	[NOT_BOOTABLE_CODE]		=	{ &COLOR_LIGHTRED,	not_bootable_message}
+	[NOT_BOOTABLE_CODE]		=	{ &COLOR_LIGHTRED,	not_bootable_message},
+	[LIVE_BOOT_CODE]		=	{ &COLOR_ORANGE,	live_boot_message}
 };
 
 static const char *VENDOR_IMG_NAME = "splash_intel";

--- a/ux.h
+++ b/ux.h
@@ -48,6 +48,7 @@ enum ux_error_code {
         BOOTIMAGE_UNTRUSTED_CODE,
         CRASH_EVENT_CODE,
         NOT_BOOTABLE_CODE,
+        LIVE_BOOT_CODE,
         MAX_ERROR_CODE
 };
 


### PR DESCRIPTION
1. Add a new macro KERNELFLINGER_SUPPORT_LIVE_BOOT for support live boot.
2. Default setting is disabled.
3. Live boot is only supported in eng and userdebug build.
4. Now set KERNELFLINGER_SUPPORT_USB_STORAGE = true only support USB
storage.
5. Need set both of KERNELFLINGER_SUPPORT_LIVE_BOOT = true and
KERNELFLINGER_SUPPORT_USB_STORAGE = true to enable USB live boot.
6. Show warning message when booting.
7. Does not save the lock/unlock state to storage.
8. Set to unlock state.
9. Verify boot status is set to orange.
10. Does not read and update the rollback index.

Tracked-On: OAM-85331
Signed-off-by: Ming Tan <ming.tan@intel.com>