### PR TITLE
Update BootloaderSeedProtocol comment about support multi RPMB partitions.

### DIFF
--- a/libkernelflinger/protocol/BootloaderSeedProtocol.h
+++ b/libkernelflinger/protocol/BootloaderSeedProtocol.h
@@ -89,6 +89,8 @@ typedef struct {
  * Get the RPMB key.
  *
  * Kernelflinger will prepare for the data buffer, and BIOS will copy the data to this buffer.
+ * If there are several RPMB partitions, then BIOS only put the RPMB keys to the RPMB partitions used by bootloader,
+ * and set the other RPMB keys to all zero.
  *
  * @num_keys  IN   the entry size of buf, in general is 6 for max RPMB partitions/keys.
  *            OUT  the final output keys number, should <= the input value.


### PR DESCRIPTION

Update the comment for function BLS_PROTOCOL_GET_RPMB_KEY. Kerneflinger
call this function to get RPMB key from BIOS.
If there are several RPMB partitions, then BIOS only put the RPMB keys
for the RPMB partitions used by bootloader, and set the other RPMB keys
to all zero.

Tracked-On: OAM-84633
Signed-off-by: Ming Tan <ming.tan@intel.com>