### PR TITLE
Update firststage mount config variable name

### DIFF
--- a/libkernelflinger/firststage_mount.c
+++ b/libkernelflinger/firststage_mount.c
@@ -129,8 +129,8 @@ EFI_STATUS install_firststage_mount_aml(enum boot_target target)
 	UINTN TableKey;
 
 #if (!defined(USE_ACPI)) && (!defined(USE_ACPIO))
-	ssdt = AmlCode;
-	ssdt_len = sizeof(AmlCode);
+	ssdt = firststage_mount_cfg_aml_code;
+	ssdt_len = sizeof(firststage_mount_cfg_aml_code);
 #else
 	return EFI_SUCCESS;
 #endif


### PR DESCRIPTION
iasl is updating from 20150619 to 20190816, the name of generated
hexadecimal aml table has changed from "AmlCode" to "FILENAME_aml_code".
Update the variable to align this change.

Tracked-On: OAM-85379
Signed-off-by: Chen, ZhiminX <zhiminx.chen@intel.com>