### PR TITLE
Fix the compile warning of size_t redefined.

### DIFF
--- a/include/libkernelflinger/lib.h
+++ b/include/libkernelflinger/lib.h
@@ -39,7 +39,9 @@
 #include <ui.h>
 #include <log.h>
 
+#ifndef DEFINED_SIZE_T
 typedef UINTN size_t;
+#endif
 typedef INTN ssize_t;
 
 #define offsetof(TYPE, MEMBER) ((UINTN) &((TYPE *)0)->MEMBER)

--- a/libsslsupport/openssl_support.h
+++ b/libsslsupport/openssl_support.h
@@ -5,6 +5,8 @@
 #include <efilib.h>
 
 typedef UINTN size_t;
+#define DEFINED_SIZE_T
+
 typedef long time_t;
 typedef VOID *FILE;
 


### PR DESCRIPTION
There are same line of 'typedef UINTN size_t;' in following files:
libsslsupport/openssl_support.h
include/libkernelflinger/lib.h

Tracked-On: OAM-86760
Signed-off-by: Ming Tan <ming.tan@intel.com>