### PR TITLE
log: save log to a file when explicitly requested 

### DIFF
--- a/include/libkernelflinger/log.h
+++ b/include/libkernelflinger/log.h
@@ -41,6 +41,8 @@ EFI_STATUS log_flush_to_var(BOOLEAN nonvol);
 
 void log(const CHAR16 *fmt, ...);
 void vlog(const CHAR16 *fmt, va_list args);
+EFI_STATUS log_open_output_file(EFI_HANDLE handle, const CHAR16 *filename);
+void log_close_output_file(void);
 
 #ifdef __DISABLE_DEBUG_PRINT
 #define DEBUG_MESSAGES 0

--- a/installer.c
+++ b/installer.c
@@ -943,6 +943,7 @@ static void usage(__attribute__((__unused__)) INTN argc,
 	Print(L"  installer is an EFI application acting like the fastboot command.\n\n");
 	Print(L" COMMANDS               fastboot commands (cf. the fastboot manual page)\n");
 	Print(L" -i                     include the device which is loaded from, must be the first option\n");
+	Print(L" -l                     output log to installer.log\n");
 	Print(L" --help, -h             print this help and exit\n");
 	Print(L" --version, -v          print Installer version and exit\n");
 	Print(L" --batch, -b FILE       run all the fastboot commands of FILE\n");
@@ -1086,6 +1087,16 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *_table)
 		}
 	}
 
+	/* Output log to the installer.log if run the command */
+	if (options) {
+		if (!strncmp(options, "-l", 2)) {
+			options += 2;
+			skip_whitespace((char **)&options);
+			if (EFI_ERROR(log_open_output_file(loaded_img->DeviceHandle, L"\\installer.log")))
+				Print(L"Invalid command [installer -l] in user mode\n");
+		}
+	}
+
 	if (!options || *options == '\0')
 		options = build_default_options();
 	store_command((char *)options, NULL);
@@ -1113,6 +1124,7 @@ exit:
 	FreePool(buf);
 	if (EFI_ERROR(ret))
 		return ret;
+	log_close_output_file();
 	return last_cmd_succeeded ? EFI_SUCCESS : EFI_INVALID_PARAMETER;
 }
 

--- a/kernelflinger.c
+++ b/kernelflinger.c
@@ -479,6 +479,17 @@ static enum boot_target check_command_line(VOID)
 			continue;
 		}
 
+		if (!StrCmp(argv[pos], L"-l")) {
+			pos++;
+			if (pos >= (argc + 1)) {
+				error(L"-l requires output kernelflinger log to the file");
+				goto out;
+			}
+			if (EFI_ERROR(log_open_output_file(g_disk_device, L"\\kernelflinger.log")))
+				error(L"unexpected argument -l");
+			continue;
+		}
+
 		/* If we get here the argument isn't recognized */
 		if (pos == 0) {
 			/* EFI is inconsistent and only seems to populate the image

--- a/libkernelflinger/android.c
+++ b/libkernelflinger/android.c
@@ -431,6 +431,7 @@ static inline EFI_STATUS handover_jump(EFI_HANDLE image,
 #endif
         log(L"handover jump ...\n");
 
+        log_close_output_file();
         ret = setup_gdt();
         if (EFI_ERROR(ret)) {
                 efi_perror(ret, L"Failed to setup GDT");


### PR DESCRIPTION
   If the installer.efi or loader.efi are supplied with
the -l parameter, the logs are appended to respectively the
installer.log or loader.log files on the device where these EFI
binaries are located.

  If there is on the user mode,the logs will not append to the files.

Signed-off-by: Yanhongx.Zhou <yanhongx.zhou@intel.com>
Tracked-On: OAM-80876