### PR TITLE
Remove early mount's dependency for acpi/acpio partitons

### DIFF
--- a/libkernelflinger/Android.mk
+++ b/libkernelflinger/Android.mk
@@ -273,16 +273,15 @@ endif  # KERNELFLINGER_USE_RPMB
 ifeq ($(BOARD_FIRSTSTAGE_MOUNT_ENABLE),true)
     LOCAL_CFLAGS += -DUSE_FIRSTSTAGE_MOUNT
     LOCAL_SRC_FILES += firststage_mount.c
-ifeq ($(filter true, $(TARGET_USE_ACPI) $(TARGET_USE_ACPIO)),)
     IASL := $(INTEL_PATH_BUILD)/acpi-tools/linux64/bin/iasl
     GEN := $(res_intermediates)/firststage_mount_cfg.h
     IASL_CFLAGS := $(filter -D%,$(subst -D ,-D,$(strip $(LOCAL_CFLAGS))))
+    IASL_CFLAGS := $(filter-out -DBOARD_ACPIO%,$(IASL_CFLAGS))
     LOCAL_GENERATED_SOURCES += $(GEN)
 
 $(GEN): $(FIRST_STAGE_MOUNT_CFG_FILE)
 	$(hide) $(IASL) -p $(@:.h=) $(IASL_CFLAGS) -tc $<
 	$(hide) mv $(@:.h=.hex) $@
-endif # not TARGET_USE_ACPI not TARGET_USE_ACPIO
 endif # BOARD_FIRSTSTAGE_MOUNT_ENABLE
 
 ifeq ($(BOARD_DISK_BUS),ff.ff)

--- a/libkernelflinger/firststage_mount.c
+++ b/libkernelflinger/firststage_mount.c
@@ -36,9 +36,7 @@
 
 #include "acpi.h"
 #include "firststage_mount.h"
-#if (!defined(USE_ACPI)) && (!defined(USE_ACPIO))
 #include "firststage_mount_cfg.h"
-#endif
 #include "lib.h"
 #include "protocol/AcpiTableProtocol.h"
 #include "storage.h"
@@ -128,12 +126,8 @@ EFI_STATUS install_firststage_mount_aml(enum boot_target target)
 	UINTN ssdt_len;
 	UINTN TableKey;
 
-#if (!defined(USE_ACPI)) && (!defined(USE_ACPIO))
 	ssdt = firststage_mount_cfg_aml_code;
 	ssdt_len = sizeof(firststage_mount_cfg_aml_code);
-#else
-	return EFI_SUCCESS;
-#endif
 
 	if ((target == NORMAL_BOOT) || (target == RECOVERY) || (target == CHARGER)
 		|| (target == ESP_BOOTIMAGE) || (target == MEMORY)) {
@@ -149,8 +143,8 @@ EFI_STATUS install_firststage_mount_aml(enum boot_target target)
 
 		ret = install_acpi_table(ssdt, ssdt_len, &TableKey);
 		if (EFI_ERROR(ret)) {
-			efi_perror(ret, L"Failed to install ssdt.");
-			return ret;
+			efi_perror(ret, L"Warning: failed to install ssdt.");
+			return EFI_SUCCESS;
 		}
 	}
 


### PR DESCRIPTION
The early mount table is revised by BIOS and osloader before
loading by kernel, it generates the difference between the source
table from acpi/acpio partitons and the destination table from
kernel, which can not pass VTS check. So integrate early mount
table directly, rather than load it from acpi/acpio partitons.

Tracked-On: OAM-86713
Signed-off-by: Chen, ZhiminX <zhiminx.chen@intel.com>