### PR TITLE
Crashmode: support the lspci shell command

### DIFF
--- a/doc/crashmode.md
+++ b/doc/crashmode.md
@@ -207,7 +207,7 @@ Record Table) region prepended by `BERR` magic.
 
 ### shell devmem Command
 
-The `shell devmem ADDRESS [WIDTH [VALUE]]` command perform a
+The `shell devmem ADDRESS [WIDTH [VALUE]]` command performs a
 read/write access from physical `ADDRESS`.  It is designed to allow
 read/write accessed to and from registers.
 
@@ -224,7 +224,7 @@ $ adb shell devmem 0x7aed6c60
 
 ### shell lsacpi command
 
-The `shell lsacpi` list all the ACPI table, their location in RAM and
+The `shell lsacpi` lists all the ACPI table, their location in RAM and
 their size.
 
 ```bash

--- a/doc/crashmode.md
+++ b/doc/crashmode.md
@@ -122,6 +122,7 @@ Crashmode adb implementation is limited to the following commands:
 - shell help COMMAND: print the help for COMMAND
 - shell devmem ADDRESS [WIDTH [VALUE]]: read/write from physical address
 - shell lsacpi: list the ACPI tables
+- shell lspci: list the PCI devices
 - shell hexdump ADDRESS LENGTH: Hexdump a memory region
 - shell inb | inw | inl IOPORT: Perform a read operation on the given I/O port
 - shell outb | outw | outl IOPORT DATA: Perform a write operation on the given I/O port
@@ -238,6 +239,26 @@ MCFG  0x7AED6A80     60
 HPET  0x7AED6A40     56
 NHLT  0x7AED3AD0   1323
 TPM2  0x7AED6420     52
+```
+
+### shell lspci command
+
+The `shell lspci` lists all the PCI devices.
+
+```bash
+$ adb shell lspci
+00:00.0 Host bridge: 8086:5AF0 (rev 0B)
+00:00.1 Signal processing controller: 8086:5A8C (rev 0B)
+00:00.2 Non-Essential Instrumentation: 8086:5A8E (rev 0B)
+00:02.0 VGA compatible controller: 8086:5A84 (rev 0B)
+00:03.0 Multimedia controller: 8086:5A88 (rev 0B)
+00:0D.1 8086:5A94 (rev 0B)
+00:0D.2 Serial bus controllers: 8086:5A96 (rev 0B)
+00:0D.3 RAM memory: 8086:5AEC (rev 0B)
+00:0E.0 Audio device: 8086:5A98 (rev 0B)
+00:0F.0 Communication controller: 8086:5A9A (rev 0B)
+00:0F.1 Communication controller: 8086:5A9C (rev 0B)
+[...]
 ```
 
 ### shell hexdump command

--- a/libadb/Android.mk
+++ b/libadb/Android.mk
@@ -24,6 +24,8 @@ LOCAL_SRC_FILES := \
 	lsacpi.c \
 	hexdump.c \
 	ioport.c \
-	lspartition.c
+	lspartition.c \
+	pci_class.c \
+	lspci.c
 
 include $(BUILD_EFI_STATIC_LIBRARY)

--- a/libadb/devmem.c
+++ b/libadb/devmem.c
@@ -112,12 +112,12 @@ static EFI_STATUS devmem_main(INTN argc, const char **argv)
 shcmd_t devmem_shcmd = {
 	.name = "devmem",
 	.summary = "Read/write from physical address",
-	.help = "Usage: devmem ADDRESS [WIDTH [VALUE]]\n\
-\n\
-Read/write from physical address\n\
-\n\
-    ADDRESS  Address to act upon\n\
-    WIDTH    Width (8/16/...)\n\
-    VALUE    Data to be written",
+	.help = "Usage: devmem ADDRESS [WIDTH [VALUE]]\n"
+	"\n"
+	"Read/write from physical address\n"
+	"\n"
+	"    ADDRESS  Address to act upon\n"
+	"    WIDTH    Width (8/16/...)\n"
+	"    VALUE    Data to be written",
 	.main = devmem_main
 };

--- a/libadb/ioport.c
+++ b/libadb/ioport.c
@@ -52,13 +52,6 @@ static inline UINT16 inw(int port)
 	return val;
 }
 
-static inline UINT32 inl(int port)
-{
-	UINT32 val;
-	__asm__ __volatile__("inl %w1, %0" : "=a"(val) : "Nd"(port));
-	return val;
-}
-
 static inline void outb(UINT8 val, int port)
 {
 	__asm__ __volatile__("outb %b0, %w1" : : "a"(val), "Nd"(port));
@@ -67,11 +60,6 @@ static inline void outb(UINT8 val, int port)
 static inline void outw(UINT16 val, int port)
 {
 	__asm__ __volatile__("outw %w0, %w1" : : "a"(val), "Nd"(port));
-}
-
-static inline void outl(UINT32 val, int port)
-{
-	__asm__ __volatile__("outl %0, %w1" : : "a"(val), "Nd"(port));
 }
 
 static const CHAR16 *VALUE_FORMAT[] = {

--- a/libadb/ioport.c
+++ b/libadb/ioport.c
@@ -34,9 +34,9 @@
 
 #include "ioport.h"
 
-static const char * const usage = "Usage:\n\
-  inb|inw|inl IOPORT\n\
-  outb|outw|outl IOPORT DATA";
+static const char * const usage = "Usage:\n"
+	"  inb|inw|inl IOPORT\n"
+	"  outb|outw|outl IOPORT DATA";
 
 static inline UINT8 inb(int port)
 {

--- a/libadb/ioport.h
+++ b/libadb/ioport.h
@@ -35,6 +35,19 @@
 
 #include "shell_service.h"
 
+static inline UINT32 inl(int port)
+{
+	UINT32 val;
+
+	__asm__ __volatile__("inl %w1, %0" : "=a"(val) : "Nd"(port));
+	return val;
+}
+
+static inline void outl(UINT32 val, int port)
+{
+	__asm__ __volatile__("outl %0, %w1" : : "a"(val), "Nd"(port));
+}
+
 extern shcmd_t inb_shcmd;
 extern shcmd_t inw_shcmd;
 extern shcmd_t inl_shcmd;

--- a/libadb/lspci.c
+++ b/libadb/lspci.c
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2019, Intel Corporation
+ * All rights reserved.
+ *
+ * Authors: Jeremy Compostella <jeremy.compostella@intel.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <lib.h>
+
+#include "ioport.h"
+#include "lspci.h"
+#include "pci_class.h"
+
+typedef union {
+	struct {
+		UINT8 function : 3;
+		UINT8 device : 5;
+		UINT8 bus : 8;
+	};
+	UINT16 raw;
+} pci_dev_t;
+
+typedef struct {
+	UINT16 vendor;
+	UINT16 device;
+	UINT16 command;
+	UINT16 status;
+	UINT8 revision;
+	struct {
+		UINT8 interface;
+		UINT8 sub;
+		UINT8 base;
+	} class;
+} __attribute__((packed)) pci_header_t;
+
+static UINT32 pci_read_config32(pci_dev_t dev, UINT16 reg)
+{
+	outl(0x80000000 | dev.raw << 8 | (reg & ~3), 0xcf8);
+	return inl(0xcfc + (reg & 3));
+}
+
+static void pci_read_config(pci_dev_t dev, void *buf, UINT16 count)
+{
+	UINTN i;
+
+	for (i = 0; i < count; i += sizeof(UINT32))
+		*(UINT32 *)&buf[i] = pci_read_config32(dev, i);
+}
+
+enum class_fmt {
+	DEFAULT,
+	NUMERIC,
+	BOTH
+};
+
+static UINTN dump_size, class_fmt;
+
+static const struct {
+	const char *option;
+	UINTN *variable;
+	UINTN value;
+} OPTIONS[] = {
+	{ .option = "-x", .variable = &dump_size, .value = 0x40 },
+	{ .option = "-xxx", .variable = &dump_size, .value = 0x100 },
+	{ .option = "-n", .variable = &class_fmt, .value = NUMERIC },
+	{ .option = "-nn", .variable = &class_fmt, .value = BOTH }
+};
+
+static EFI_STATUS lspci_main(INTN argc, const char **argv)
+{
+	UINTN i, j;
+	pci_dev_t dev;
+	pci_header_t header;
+	unsigned char *buf = NULL;
+	const char *class;
+
+	dump_size = class_fmt = 0;
+	for (i = 1; i < (UINTN)argc; i++) {
+		for (j = 0; j < ARRAY_SIZE(OPTIONS); j++) {
+			if (!strcmp(argv[i], OPTIONS[j].option)) {
+				*(OPTIONS[j].variable) = OPTIONS[j].value;
+				break;
+			}
+		}
+		if (j == ARRAY_SIZE(OPTIONS))
+			return EFI_INVALID_PARAMETER;
+	}
+
+	if (dump_size) {
+		buf = AllocatePool(dump_size);
+		if (!buf) {
+			error(L"Failed to allocate the dump buffer");
+			return EFI_OUT_OF_RESOURCES;
+		}
+	}
+
+	for (i = 0, dev.raw = 0; i <= (UINT16)-1; i++, dev.raw = i) {
+		UINT32 val = pci_read_config32(dev, 0);
+
+		if (val == 0xffffffff || val == 0x00000000 ||
+		    val == 0x0000ffff || val == 0xffff0000)
+			continue;
+
+		pci_read_config(dev, &header, sizeof(header));
+
+		ss_printf(L"%02x:%02x.%d ", dev.bus, dev.device, dev.function);
+
+		class = pci_class_string(header.class.base, header.class.sub);
+		switch (class_fmt) {
+		case DEFAULT:
+			if (class) {
+				ss_printf(L"%a", class);
+				break;
+			}
+
+		case NUMERIC:
+			ss_printf(L"%02x%02x", header.class.base,
+				  header.class.sub);
+			break;
+
+		case BOTH:
+			ss_printf(L"%a [%02x%02x]", class,
+				  header.class.base, header.class.sub);
+			break;
+		}
+
+		ss_printf(L": %04x:%04x (rev %02x)\n",
+			  header.vendor, header.device, header.revision);
+
+		if (buf) {
+			pci_read_config(dev, buf, dump_size);
+			ss_hexdump(buf, dump_size, 0, FALSE);
+			ss_printf(L"\n");
+		}
+	}
+
+	if (buf)
+		FreePool(buf);
+
+	return EFI_SUCCESS;
+}
+
+shcmd_t lspci_shcmd = {
+	.name = "lspci",
+	.summary = "List the PCI Devices",
+	.help = "Usage: lspci [OPTIONS]\n"
+	"OPTIONS:\n"
+	"-x      Hexdump of the standard part of the config space\n"
+	"-xxx    Hexdump of the whole config space\n"
+	"-n	Use numeric ID's\n"
+	"-nn	Use both textual and numeric ID's",
+	.main = lspci_main
+};

--- a/libadb/lspci.h
+++ b/libadb/lspci.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2019, Intel Corporation
+ * All rights reserved.
+ *
+ * Authors: Jeremy Compostella <jeremy.compostella@intel.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef _LSPCI_H_
+#define _LSPCI_H_
+
+#include "shell_service.h"
+
+extern shcmd_t lspci_shcmd;
+
+#endif	/* _LSPCI_H_ */

--- a/libadb/pci_class.c
+++ b/libadb/pci_class.c
@@ -1,0 +1,274 @@
+/*
+ * Copyright (c) 2019, Intel Corporation
+ * All rights reserved.
+ *
+ * Authors: Jeremy Compostella <jeremy.compostella@intel.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "pci_class.h"
+
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof(*x))
+
+typedef struct {
+	UINT8 id;
+	char *name;
+} assoc_t;
+
+static assoc_t UNCLASSIFIED[] = {
+	{ 0x00,	"Non-VGA unclassified device" },
+	{ 0x01,	"VGA compatible unclassified device" },
+	{ 0xFF, NULL }
+};
+
+static assoc_t MASS[] = {
+	{ 0x00,	"SCSI storage controller" },
+	{ 0x01,	"IDE interface" },
+	{ 0x02,	"Floppy disk controller" },
+	{ 0x03,	"IPI bus controller" },
+	{ 0x04,	"RAID bus controller" },
+	{ 0x05,	"ATA controller" },
+	{ 0x06,	"SATA controller" },
+	{ 0x07,	"Serial Attached SCSI controller" },
+	{ 0x08,	"Non-Volatile memory controller" },
+	{ 0x80,	"Mass storage controller" },
+	{ 0xFF, NULL }
+};
+
+static assoc_t NETWORK[] = {
+	{ 0x00,	"Ethernet controller" },
+	{ 0x01,	"Token ring network controller" },
+	{ 0x02,	"FDDI network controller" },
+	{ 0x03,	"ATM network controller" },
+	{ 0x04,	"ISDN controller" },
+	{ 0x05,	"WorldFip controller" },
+	{ 0x06,	"PICMG controller" },
+	{ 0x07,	"Infiniband controller" },
+	{ 0x08,	"Fabric controller" },
+	{ 0x80,	"Network controller" },
+	{ 0xFF, NULL }
+};
+
+static assoc_t DISPLAY[] = {
+	{ 0x00,	"VGA compatible controller" },
+	{ 0x01,	"XGA compatible controller" },
+	{ 0x02,	"3D controller" },
+	{ 0x80,	"Display controller" },
+	{ 0xFF, NULL }
+};
+
+static assoc_t MULTIMEDIA[] = {
+	{ 0x00,	"Multimedia video controller" },
+	{ 0x01,	"Multimedia audio controller" },
+	{ 0x02,	"Computer telephony device" },
+	{ 0x03,	"Audio device" },
+	{ 0x80,	"Multimedia controller" },
+	{ 0xFF, NULL }
+};
+
+static assoc_t MEMORY[] = {
+	{ 0x00,	"RAM memory" },
+	{ 0x01,	"FLASH memory" },
+	{ 0x80,	"Memory controller" },
+	{ 0xFF, NULL }
+};
+
+static assoc_t BRIDGE[] = {
+	{ 0x00,	"Host bridge" },
+	{ 0x01,	"ISA bridge" },
+	{ 0x02,	"EISA bridge" },
+	{ 0x03,	"MicroChannel bridge" },
+	{ 0x04,	"PCI bridge" },
+	{ 0x05,	"PCMCIA bridge" },
+	{ 0x06,	"NuBus bridge" },
+	{ 0x07,	"CardBus bridge" },
+	{ 0x08,	"RACEway bridge" },
+	{ 0x09,	"Semi-transparent PCI-to-PCI bridge" },
+	{ 0x0a,	"InfiniBand to PCI host bridge" },
+	{ 0x80,	"Bridge" },
+	{ 0xFF, NULL }
+};
+
+static assoc_t SIMPLE[] = {
+	{ 0x00,	"Serial controller" },
+	{ 0x01,	"Parallel controller" },
+	{ 0x02,	"Multiport serial controller" },
+	{ 0x03,	"Modem" },
+	{ 0x04,	"GPIB controller" },
+	{ 0x05,	"Smard Card controller" },
+	{ 0x80,	"Communication controller" },
+	{ 0xFF, NULL }
+};
+
+static assoc_t BASE[] = {
+	{ 0x00,	"PIC" },
+	{ 0x01,	"DMA controller" },
+	{ 0x02,	"Timer" },
+	{ 0x03,	"RTC" },
+	{ 0x04,	"PCI Hot-plug controller" },
+	{ 0x05,	"SD Host controller" },
+	{ 0x06,	"IOMMU" },
+	{ 0x80,	"System peripheral" },
+	{ 0xFF, NULL }
+};
+
+static assoc_t INPUT[] = {
+	{ 0x00,	"Keyboard controller" },
+	{ 0x01,	"Digitizer Pen" },
+	{ 0x02,	"Mouse controller" },
+	{ 0x03,	"Scanner controller" },
+	{ 0x04,	"Gameport controller" },
+	{ 0x80,	"Input device controller" },
+	{ 0xFF, NULL }
+};
+
+static assoc_t DOCKING[] = {
+	{ 0x00,	"Generic Docking Station" },
+	{ 0x80,	"Docking Station" },
+	{ 0xFF, NULL }
+};
+
+static assoc_t PROCESSOR[] = {
+	{ 0x00,	"386" },
+	{ 0x01,	"486" },
+	{ 0x02,	"Pentium" },
+	{ 0x10,	"Alpha" },
+	{ 0x20,	"Power PC" },
+	{ 0x30,	"MIPS" },
+	{ 0x40,	"Co-processor" },
+	{ 0xFF, NULL }
+};
+
+static assoc_t SERIAL[] = {
+	{ 0x00,	"FireWire (IEEE 1394" },
+	{ 0x01,	"ACCESS Bus" },
+	{ 0x02,	"SSA" },
+	{ 0x03,	"USB controller" },
+	{ 0x04,	"Fibre Channel" },
+	{ 0x05,	"SMBus" },
+	{ 0x06,	"InfiniBand" },
+	{ 0x07,	"IPMI Interface" },
+	{ 0x08,	"SERCOS interface" },
+	{ 0x09,	"CANBUS" },
+	{ 0xFF, NULL }
+};
+
+static assoc_t WIRELESS[] = {
+	{ 0x00,	"IRDA controller" },
+	{ 0x01,	"Consumer IR controller" },
+	{ 0x10,	"RF controller" },
+	{ 0x11,	"Bluetooth" },
+	{ 0x12,	"Broadband" },
+	{ 0x20,	"802.1a controller" },
+	{ 0x21,	"802.1b controller" },
+	{ 0x80,	"Wireless controller" },
+	{ 0xFF, NULL }
+};
+
+static assoc_t INTELLIGENT[] = {
+	{ 0x00,	"I2O" },
+	{ 0xFF, NULL }
+};
+
+static assoc_t SATELLITE[] = {
+	{ 0x01,	"Satellite TV controller" },
+	{ 0x02,	"Satellite audio communication controller" },
+	{ 0x03,	"Satellite voice communication controller" },
+	{ 0x04,	"Satellite data communication controller" },
+	{ 0xFF, NULL }
+};
+
+static assoc_t ENCRYPTION[] = {
+	{ 0x00,	"Network and computing encryption device" },
+	{ 0x10,	"Entertainment encryption device" },
+	{ 0x80,	"Encryption controller" },
+	{ 0xFF, NULL }
+};
+
+static assoc_t SIGNAL[] = {
+	{ 0x00,	"DPIO module" },
+	{ 0x01,	"Performance counters" },
+	{ 0x10,	"Communication synchronizer" },
+	{ 0x20,	"Signal processing management" },
+	{ 0x80,	"Signal processing controller" },
+	{ 0xFF, NULL }
+};
+
+static assoc_t PROCESSING[] = {
+	{ 0x00,	"Processing accelerators" },
+	{ 0x01,	"AI Inference Accelerator" },
+	{ 0xFF, NULL }
+};
+
+static const struct {
+	UINT8 id;
+	char *name;
+	assoc_t *subclass;
+} CLASSES[] = {
+	{ 0x00, "Unclassified", (assoc_t *)&UNCLASSIFIED },
+	{ 0x01, "Mass storage controller", (assoc_t *)&MASS },
+	{ 0x02, "Network controller", (assoc_t *)&NETWORK },
+	{ 0x03, "Display controller", (assoc_t *)&DISPLAY },
+	{ 0x04, "Multimedia device", (assoc_t *)&MULTIMEDIA },
+	{ 0x05, "Memory controller", (assoc_t *)&MEMORY },
+	{ 0x06, "Bridge device", (assoc_t *)&BRIDGE },
+	{ 0x07, "Simple communication controllers", (assoc_t *)&SIMPLE },
+	{ 0x08, "Base system peripherals", (assoc_t *)&BASE },
+	{ 0x09, "Input devices", (assoc_t *)&INPUT },
+	{ 0x0A, "Docking stations", (assoc_t *)&DOCKING },
+	{ 0x0B, "Processors", (assoc_t *)&PROCESSOR },
+	{ 0x0C, "Serial bus controllers", (assoc_t *)&SERIAL },
+	{ 0x0D, "Wireless controller", (assoc_t *)&WIRELESS },
+	{ 0x0E, "Intelligent I/O controllers", (assoc_t *)&INTELLIGENT },
+	{ 0x0F, "Satellite communication controllers", (assoc_t *)&SATELLITE },
+	{ 0x10, "Encryption/Decryption controllers", (assoc_t *)&ENCRYPTION },
+	{ 0x11, "Signal processing controllers", (assoc_t *)&SIGNAL },
+	{ 0x12, "Processing accelerators", (assoc_t *)&PROCESSING },
+	{ 0x13, "Non-Essential Instrumentation", NULL },
+	{ 0x40, "Coprocessor", NULL }
+};
+
+const char *pci_class_string(UINT8 base, UINT8 sub)
+{
+	UINTN i, j;
+	assoc_t *subclass;
+
+	for (i = 0; i < ARRAY_SIZE(CLASSES); i++)
+		if (base == CLASSES[i].id) {
+			subclass = CLASSES[i].subclass;
+			if (!subclass)
+				return CLASSES[i].name;
+
+			for (j = 0; subclass[j].name; j++)
+				if (sub == subclass[j].id)
+					return subclass[j].name;
+
+			return CLASSES[i].name;
+		}
+
+	return NULL;
+}

--- a/libadb/pci_class.h
+++ b/libadb/pci_class.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2019, Intel Corporation
+ * All rights reserved.
+ *
+ * Authors: Jeremy Compostella <jeremy.compostella@intel.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef _PCI_CLASS_H_
+#define _PCI_CLASS_H_
+
+#include <efi.h>
+
+const char *pci_class_string(UINT8 base, UINT8 sub);
+
+#endif	/* _PCI_CLASS_H_ */

--- a/libadb/shell_service.c
+++ b/libadb/shell_service.c
@@ -42,6 +42,7 @@
 #include "ioport.h"
 #include "lsacpi.h"
 #include "lspartition.h"
+#include "lspci.h"
 
 #define MAX_ARGS	8
 
@@ -65,6 +66,7 @@ static shcmd_t *SHCMD[] = {
 	&list_shcmd,
 	&lsacpi_shcmd,
 	&lspartition_shcmd,
+	&lspci_shcmd,
 	&outb_shcmd,
 	&outl_shcmd,
 	&outw_shcmd

--- a/libadb/shell_service.h
+++ b/libadb/shell_service.h
@@ -37,6 +37,8 @@
 
 EFI_STATUS ss_printf(const CHAR16 *fmt, ...);
 EFI_STATUS ss_read_number(const char *arg, const char *name, UINT64 *value);
+void ss_hexdump(unsigned char *buf, UINTN length,
+		EFI_PHYSICAL_ADDRESS address, BOOLEAN canonical);
 
 #ifndef __LP64__
 EFI_STATUS ss_pae_map(EFI_PHYSICAL_ADDRESS *address, UINT64 length);


### PR DESCRIPTION
It turns out that when working on issue with regard to BIOS PCI/PCIe enumeration it is handy to be able to enumerate the PCI devices from Kernelflinger Crashmode.

This implementation shared some option with the legacy [pciutils - lspci](https://github.com/pciutils/pciutils).  this implementation uses the legacy method via I/O addresses `0xCF8` and `0xCFC` which should work on any hardware.

