### PR TITLE
Tune the code of get_current_state.

### DIFF
--- a/include/libkernelflinger/vars.h
+++ b/include/libkernelflinger/vars.h
@@ -127,7 +127,8 @@ EFI_STATUS set_slot_fallback(BOOLEAN enabled);
 enum device_state {
 	UNKNOWN_STATE = -1,
 	LOCKED = 0,
-	UNLOCKED = 1
+	UNLOCKED = 1,
+	JUST_INIT = 2
 };
 const char *get_current_state_string(void);
 EFI_GRAPHICS_OUTPUT_BLT_PIXEL *get_current_state_color();


### PR DESCRIPTION
If read the state from RPMB, then also need to check provision mode.
Also add a new state of JUST_INIT, used for init the security storage.
Also add function read_efi_device_state and write_efi_device_state.
Also simple tune the set_current_state.

Tracked-On: OAM-87085
Signed-off-by: Ming Tan <ming.tan@intel.com>