### PR TITLE
kf4cic: change string compare function without case sensitivity

### DIFF
--- a/kf4cic.c
+++ b/kf4cic.c
@@ -133,7 +133,7 @@ CHAR16 *absolute_path(EFI_HANDLE image_handle, CHAR16 *file)
 
 	len = StrLen(base_path);
 	if (len > 4) {
-		if (StriCmp(base_path + len - 4, L".EFI") == 0) {
+		if (StrcaseCmp(base_path + len - 4, L".EFI") == 0) {
 			UINTN i = len - 4;
 
 			while (i > 0 && base_path[i] != L'\\')


### PR DESCRIPTION
StriCmp is not always a string compare function without case sensitivity.
Replace StriCmp with StrcaseCmp which is a string compare function
without case sensitivity.

Tracked-On: OAM-88246
Signed-off-by: JianFeng,Zhou <jianfeng.zhou@intel.com>