### PR TITLE
Skip the empty or one space SMBIOS string.

### DIFF
--- a/libkernelflinger/vars.c
+++ b/libkernelflinger/vars.c
@@ -609,11 +609,17 @@ static void CDD_clean_string(char *buf)
 	}
 }
 
+static BOOLEAN valid_dmidata(char *data)
+{
+	return dmidata && dmidata != SMBIOS_UNDEFINED &&
+			*dmidata && !(dmidata[0] == ' ' && dmidata[1] != '\0');
+}
+
 #define SMBIOS_TO_BUFFER(buffer, type, field) do { \
 	if (!buffer[0]) { \
 		UINTN bufsz = sizeof(buffer); \
 		char *dmidata = SMBIOS_GET_STRING(type, field); \
-		if (dmidata && dmidata != SMBIOS_UNDEFINED) { \
+		if (valid_dmidata(dmidata)) \
 			strncpy((CHAR8 *)buffer, (CHAR8 *)dmidata, bufsz); \
 			buffer[bufsz - 1] = '\0'; \
 		} \


### PR DESCRIPTION
Some BIOS will set SMBIOS string to empty or only one space, we need to
skip such string.
KBL NUC BIOS will set the device serial number to one space in SMBIOS type
TYPE_PRODUCT, the old code will cause the serial number to only one
space and too short to use, use this patch, kernelflinger get get the
correct device serial number from SMBIOS type TYPE_BOARD.

Signed-off-by: Ming Tan <ming.tan@intel.com>