### PR TITLE
boot: set Trusty memory size to 20M for rowhammer mitigation

### DIFF
--- a/libkernelflinger/trusty_efi.c
+++ b/libkernelflinger/trusty_efi.c
@@ -58,7 +58,7 @@
 #define VMM_MEM_BASE             0x34C00000
 #define VMM_MEM_SIZE             0x01000000
 #define TRUSTY_MEM_BASE          0x32C00000
-#define TRUSTY_MEM_SIZE          0x01200000
+#define TRUSTY_MEM_SIZE          0x01400000
 #define TRUSTY_KEYBOX_KEY_SIZE   32
  /*
  * this is the startup structure containes the informations for ikgt and trusty


### PR DESCRIPTION
The change only availbe for efi platform.
Barrier size will be increased to 2M in this case, thus trusty address
is 2M align in order to use big page table

Signed-off-by: Chen Gang G <gang.g.chen@intel.com>
Tracked-On: OAM-88853