### PR TITLE
Revert "UI: fit low resolution screen"

### DIFF
--- a/libfastboot/fastboot_ui.c
+++ b/libfastboot/fastboot_ui.c
@@ -275,7 +275,7 @@ EFI_STATUS fastboot_ui_init(void)
 
 	/* Use large enough margin to not overlap ui_print/ui_error
 	 * area. */
-	margin = swidth * 4 / 100;
+	margin = swidth * 12 / 100;
 	ret = EFI_UNSUPPORTED;
 
 	droid = ui_image_get(DROID_IMG_NAME);


### PR DESCRIPTION
the patch "UI: fit low resolution screen" cause some user build UI display error, need to be reverted