### PR TITLE
support android bootctrl 1.1

### DIFF
--- a/avb/libavb_ab/avb_ab_flow.c
+++ b/avb/libavb_ab/avb_ab_flow.c
@@ -26,24 +26,22 @@
 
 bool avb_ab_data_verify_and_byteswap(const AvbABData* src, AvbABData* dest) {
   /* Ensure magic is correct. */
-  if (avb_safe_memcmp(src->magic, AVB_AB_MAGIC, AVB_AB_MAGIC_LEN) != 0) {
+  if (src->magic != BOOT_CTRL_MAGIC) {
     avb_error("Magic is incorrect.\n");
     return false;
   }
 
   avb_memcpy(dest, src, sizeof(AvbABData));
-  dest->crc32 = avb_be32toh(dest->crc32);
-
   /* Ensure we don't attempt to access any fields if the major version
    * is not supported.
    */
-  if (dest->version_major > AVB_AB_MAJOR_VERSION) {
+  if (dest->version_major > BOOT_CTRL_VERSION) {
     avb_error("No support for given major version.\n");
     return false;
   }
 
   /* Bail if CRC32 doesn't match. */
-  if (dest->crc32 !=
+  if (dest->crc32_le !=
       avb_crc32((const uint8_t*)dest, sizeof(AvbABData) - sizeof(uint32_t))) {
     avb_error("CRC32 does not match.\n");
     return false;
@@ -55,22 +53,24 @@ bool avb_ab_data_verify_and_byteswap(const AvbABData* src, AvbABData* dest) {
 void avb_ab_data_update_crc_and_byteswap(const AvbABData* src,
                                          AvbABData* dest) {
   avb_memcpy(dest, src, sizeof(AvbABData));
-  dest->crc32 = avb_htobe32(
-      avb_crc32((const uint8_t*)dest, sizeof(AvbABData) - sizeof(uint32_t)));
+  dest->crc32_le = avb_crc32((const uint8_t*)dest,
+                             sizeof(AvbABData) - sizeof(uint32_t));
 }
 
 void avb_ab_data_init(AvbABData* data) {
   avb_memset(data, '\0', sizeof(AvbABData));
-  avb_memcpy(data->magic, AVB_AB_MAGIC, AVB_AB_MAGIC_LEN);
-  data->version_major = AVB_AB_MAJOR_VERSION;
-  data->version_minor = AVB_AB_MINOR_VERSION;
-  data->slots[0].priority = AVB_AB_MAX_PRIORITY;
-  data->slots[0].tries_remaining = AVB_AB_MAX_TRIES_REMAINING;
-  data->slots[0].successful_boot = 0;
-  data->slots[1].priority = AVB_AB_MAX_PRIORITY - 1;
-  data->slots[1].tries_remaining = AVB_AB_MAX_TRIES_REMAINING;
-  data->slots[1].successful_boot = 0;
+  data->magic = BOOT_CTRL_MAGIC;
+  data->version_major = BOOT_CTRL_VERSION;
+  data->nb_slot = sizeof(data->slot_info)/sizeof(data->slot_info[0]);
+  data->slot_info[0].priority = AVB_AB_MAX_PRIORITY;
+  data->slot_info[0].tries_remaining = AVB_AB_MAX_TRIES_REMAINING;
+  data->slot_info[0].successful_boot = 0;
+  data->slot_info[1].priority = AVB_AB_MAX_PRIORITY - 1;
+  data->slot_info[1].tries_remaining = AVB_AB_MAX_TRIES_REMAINING;
+  data->slot_info[1].successful_boot = 0;
+  avb_memcpy(data->slot_suffix, "_a", 2);
 }
+
 
 /* The AvbABData struct is stored 2048 bytes into the 'misc' partition
  * following the 'struct bootloader_message' field. The struct is
@@ -152,9 +152,9 @@ static void slot_normalize(AvbABSlotData* slot) {
       /* We've exhausted all tries -> unbootable. */
       slot_set_unbootable(slot);
     }
-    if (slot->tries_remaining > 0 && slot->successful_boot) {
-      /* Illegal state - avb_ab_mark_slot_successful() will clear
-       * tries_remaining when setting successful_boot.
+    if (slot->tries_remaining > 1 && slot->successful_boot) {
+      /* Illegal state - avb_ab_mark_slot_successful() will set
+       * tries_remaining to 1 when setting successful_boot.
        */
       slot_set_unbootable(slot);
     }
@@ -162,6 +162,7 @@ static void slot_normalize(AvbABSlotData* slot) {
     slot_set_unbootable(slot);
   }
 }
+
 
 static const char* slot_suffixes[2] = {"_a", "_b"};
 
@@ -184,8 +185,8 @@ static AvbIOResult load_metadata(AvbABOps* ab_ops,
    * unbootable and all unbootable states are represented with
    * (priority=0, tries_remaining=0, successful_boot=0).
    */
-  slot_normalize(&ab_data->slots[0]);
-  slot_normalize(&ab_data->slots[1]);
+  slot_normalize(&ab_data->slot_info[0]);
+  slot_normalize(&ab_data->slot_info[1]);
   return AVB_IO_RESULT_OK;
 }
 
@@ -227,7 +228,7 @@ AvbABFlowResult avb_ab_flow(AvbABOps* ab_ops,
 
   /* Validate all bootable slots. */
   for (n = 0; n < 2; n++) {
-    if (slot_is_bootable(&ab_data.slots[n])) {
+    if (slot_is_bootable(&ab_data.slot_info[n])) {
       AvbSlotVerifyResult verify_result;
       bool set_slot_unbootable = false;
 
@@ -291,21 +292,21 @@ AvbABFlowResult avb_ab_flow(AvbABOps* ab_ops,
                    avb_slot_verify_result_to_string(verify_result),
                    " - setting unbootable.\n",
                    NULL);
-        slot_set_unbootable(&ab_data.slots[n]);
+        slot_set_unbootable(&ab_data.slot_info[n]);
       }
     }
   }
 
-  if (slot_is_bootable(&ab_data.slots[0]) &&
-      slot_is_bootable(&ab_data.slots[1])) {
-    if (ab_data.slots[1].priority > ab_data.slots[0].priority) {
+  if (slot_is_bootable(&ab_data.slot_info[0]) &&
+      slot_is_bootable(&ab_data.slot_info[1])) {
+    if (ab_data.slot_info[1].priority > ab_data.slot_info[0].priority) {
       slot_index_to_boot = 1;
     } else {
       slot_index_to_boot = 0;
     }
-  } else if (slot_is_bootable(&ab_data.slots[0])) {
+  } else if (slot_is_bootable(&ab_data.slot_info[0])) {
     slot_index_to_boot = 0;
-  } else if (slot_is_bootable(&ab_data.slots[1])) {
+  } else if (slot_is_bootable(&ab_data.slot_info[1])) {
     slot_index_to_boot = 1;
   } else {
     /* No bootable slots! */
@@ -370,9 +371,9 @@ AvbABFlowResult avb_ab_flow(AvbABOps* ab_ops,
   }
 
   /* ... and decrement tries remaining, if applicable. */
-  if (!ab_data.slots[slot_index_to_boot].successful_boot &&
-      ab_data.slots[slot_index_to_boot].tries_remaining > 0) {
-    ab_data.slots[slot_index_to_boot].tries_remaining -= 1;
+  if (!ab_data.slot_info[slot_index_to_boot].successful_boot &&
+      ab_data.slot_info[slot_index_to_boot].tries_remaining > 0) {
+    ab_data.slot_info[slot_index_to_boot].tries_remaining -= 1;
   }
 
 out:
@@ -420,14 +421,14 @@ AvbIOResult avb_ab_mark_slot_active(AvbABOps* ab_ops,
   }
 
   /* Make requested slot top priority, unsuccessful, and with max tries. */
-  ab_data.slots[slot_number].priority = AVB_AB_MAX_PRIORITY;
-  ab_data.slots[slot_number].tries_remaining = AVB_AB_MAX_TRIES_REMAINING;
-  ab_data.slots[slot_number].successful_boot = 0;
+  ab_data.slot_info[slot_number].priority = AVB_AB_MAX_PRIORITY;
+  ab_data.slot_info[slot_number].tries_remaining = AVB_AB_MAX_TRIES_REMAINING;
+  ab_data.slot_info[slot_number].successful_boot = 0;
 
   /* Ensure other slot doesn't have as high a priority. */
   other_slot_number = 1 - slot_number;
-  if (ab_data.slots[other_slot_number].priority == AVB_AB_MAX_PRIORITY) {
-    ab_data.slots[other_slot_number].priority = AVB_AB_MAX_PRIORITY - 1;
+  if (ab_data.slot_info[other_slot_number].priority == AVB_AB_MAX_PRIORITY) {
+    ab_data.slot_info[other_slot_number].priority = AVB_AB_MAX_PRIORITY - 1;
   }
 
   ret = AVB_IO_RESULT_OK;
@@ -451,7 +452,7 @@ AvbIOResult avb_ab_mark_slot_unbootable(AvbABOps* ab_ops,
     goto out;
   }
 
-  slot_set_unbootable(&ab_data.slots[slot_number]);
+  slot_set_unbootable(&ab_data.slot_info[slot_number]);
 
   ret = AVB_IO_RESULT_OK;
 
@@ -474,14 +475,14 @@ AvbIOResult avb_ab_mark_slot_successful(AvbABOps* ab_ops,
     goto out;
   }
 
-  if (!slot_is_bootable(&ab_data.slots[slot_number])) {
+  if (!slot_is_bootable(&ab_data.slot_info[slot_number])) {
     avb_error("Cannot mark unbootable slot as successful.\n");
     ret = AVB_IO_RESULT_OK;
     goto out;
   }
 
-  ab_data.slots[slot_number].tries_remaining = 0;
-  ab_data.slots[slot_number].successful_boot = 1;
+  ab_data.slot_info[slot_number].tries_remaining = 0;
+  ab_data.slot_info[slot_number].successful_boot = 1;
 
   ret = AVB_IO_RESULT_OK;
 

--- a/avb/libavb_ab/avb_ab_ops.h
+++ b/avb/libavb_ab/avb_ab_ops.h
@@ -39,7 +39,7 @@ extern "C" {
 struct AvbABOps;
 typedef struct AvbABOps AvbABOps;
 
-struct AvbABData;
+struct bootloader_control;
 
 /* High-level operations/functions/methods for A/B that are platform
  * dependent.
@@ -59,7 +59,8 @@ struct AvbABOps {
    * Implementations will typically want to use avb_ab_data_read()
    * here to use the 'misc' partition for persistent storage.
    */
-  AvbIOResult (*read_ab_metadata)(AvbABOps* ab_ops, struct AvbABData* data);
+  AvbIOResult (*read_ab_metadata)(AvbABOps* ab_ops,
+                                  struct bootloader_control* data);
 
   /* Writes A/B metadata to persistent storage. This will byteswap and
    * update the CRC as needed. Returns AVB_IO_RESULT_OK on success,
@@ -69,7 +70,7 @@ struct AvbABOps {
    * here to use the 'misc' partition for persistent storage.
    */
   AvbIOResult (*write_ab_metadata)(AvbABOps* ab_ops,
-                                   const struct AvbABData* data);
+                                   const struct bootloader_control* data);
 };
 
 #ifdef __cplusplus

--- a/include/android.h
+++ b/include/android.h
@@ -74,12 +74,12 @@ struct boot_img_hdr
 } __attribute__((packed)) ;
 
 /*
-** +-----------------+ 
+** +-----------------+
 ** | boot header     | 1 page
 ** +-----------------+
-** | kernel          | n pages  
+** | kernel          | n pages
 ** +-----------------+
-** | ramdisk         | m pages  
+** | ramdisk         | m pages
 ** +-----------------+
 ** | second stage    | o pages
 ** +-----------------+
@@ -196,54 +196,6 @@ struct bootloader_message_ab {
 _Static_assert(sizeof(struct bootloader_message_ab) == 4096,
               "struct bootloader_message_ab size changes");
 #endif
-
-#define BOOT_CTRL_MAGIC   0x42414342 /* Bootloader Control AB */
-#define BOOT_CTRL_VERSION 1
-
-struct slot_metadata {
-    // Slot priority with 15 meaning highest priority, 1 lowest
-    // priority and 0 the slot is unbootable.
-    uint8_t priority : 4;
-    // Number of times left attempting to boot this slot.
-    uint8_t tries_remaining : 3;
-    // 1 if this slot has booted successfully, 0 otherwise.
-    uint8_t successful_boot : 1;
-    // 1 if this slot is corrupted from a dm-verity corruption, 0
-    // otherwise.
-    uint8_t verity_corrupted : 1;
-    // Reserved for further use.
-    uint8_t reserved : 7;
-} __attribute__((packed));
-
-/* Bootloader Control AB
- *
- * This struct can be used to manage A/B metadata. It is designed to
- * be put in the 'slot_suffix' field of the 'bootloader_message'
- * structure described above. It is encouraged to use the
- * 'bootloader_control' structure to store the A/B metadata, but not
- * mandatory.
- */
-struct bootloader_control {
-    // NUL terminated active slot suffix.
-    char slot_suffix[4];
-    // Bootloader Control AB magic number (see BOOT_CTRL_MAGIC).
-    uint32_t magic;
-    // Version of struct being used (see BOOT_CTRL_VERSION).
-    uint8_t version;
-    // Number of slots being managed.
-    uint8_t nb_slot : 3;
-    // Number of times left attempting to boot recovery.
-    uint8_t recovery_tries_remaining : 3;
-    // Ensure 4-bytes alignment for slot_info field.
-    uint8_t reserved0[2];
-    // Per-slot information.  Up to 4 slots.
-    struct slot_metadata slot_info[4];
-    // Reserved for further use.
-    uint8_t reserved1[8];
-    // CRC32 of all 28 bytes preceding this field (little endian
-    // format).
-    uint32_t crc32_le;
-} __attribute__((packed));
 
 #if (__STDC_VERSION__ >= 201112L || defined(__cplusplus))
 _Static_assert(sizeof(struct bootloader_control) ==

--- a/kfld.c
+++ b/kfld.c
@@ -102,7 +102,7 @@ EFI_STATUS avb_ab_read_misc(AvbABData *avbABData)
 		return ret;
 	}
 
-	if (memcmp(avbABData->magic, AVB_AB_MAGIC, AVB_AB_MAGIC_LEN) != 0) {
+	if (avbABData->magic != BOOT_CTRL_MAGIC) {
 		debug(L"AVB AB Magic is incorrect");
 		return EFI_COMPROMISED_DATA;
 	}
@@ -125,13 +125,13 @@ EFI_STATUS get_active_slot(UINT8 *slot)
 		// Read AVB AVB data failed
 		return ret;
 	}
-	for (i = 0, highest_priority = 0; i < ARRAY_SIZE(avbABData.slots); i++) {
-		if (avbABData.slots[i].successful_boot == 0
-				&& avbABData.slots[i].tries_remaining == 0)
+	for (i = 0, highest_priority = 0; i < ARRAY_SIZE(avbABData.slot_info); i++) {
+		if (avbABData.slot_info[i].successful_boot == 0
+				&& avbABData.slot_info[i].tries_remaining == 0)
 			continue;
 
-		if (highest_priority < avbABData.slots[i].priority) {
-			highest_priority = avbABData.slots[i].priority;
+		if (highest_priority < avbABData.slot_info[i].priority) {
+			highest_priority = avbABData.slot_info[i].priority;
 			*slot = i;
 		}
 	}

--- a/libkernelflinger/slot_avb.c
+++ b/libkernelflinger/slot_avb.c
@@ -42,7 +42,7 @@
 
 /* Constants.  */
 const CHAR16 *SLOT_STORAGE_PART = MISC_LABEL;
-#define MAX_NB_SLOT	ARRAY_SIZE(((struct AvbABData *)0)->slots)
+#define MAX_NB_SLOT	ARRAY_SIZE(((struct bootloader_control *)0)->slot_info)
 #define MAX_LABEL_LEN	64
 
 static const UINTN MAX_PRIORITY    = 15;
@@ -53,10 +53,6 @@ static const UINTN SUFFIX_LEN      = 2;
 
 #define SUFFIX_INDEX(suffix) (suffix[1] - SLOT_START_CHAR)
 
-/* A/B metadata structure. */
-typedef struct AvbABSlotData slot_metadata_t;
-typedef struct AvbABData boot_ctrl_t;
-
 /* Internal. */
 static BOOLEAN is_used;
 static char _suffixes[MAX_NB_SLOT * sizeof(SUFFIX_FMT)];
@@ -66,8 +62,8 @@ static char *cur_suffix;
 
 struct AvbABOps ab_ops;
 static AvbOps *ops;
-static boot_ctrl_t boot_ctrl;
-static AvbABSlotData *slots = boot_ctrl.slots;
+static bootloader_control boot_ctrl;
+static AvbABSlotData *slots = boot_ctrl.slot_info;
 
 static const CHAR16 *label_with_suffix(const CHAR16 *label, const char *suffix)
 {
@@ -224,7 +220,6 @@ static EFI_STATUS select_highest_priority_slot(void)
 EFI_STATUS slot_init(void)
 {
 	EFI_STATUS ret;
-	CHAR8 *magic;
 	UINTN i;
 	UINTN nb_slot;
 
@@ -266,13 +261,9 @@ EFI_STATUS slot_init(void)
 		debug(L"No A/B metadata");
 		return EFI_SUCCESS;
 	}
-	debug(L"Avb magic 0x%x, 0x%x, 0x%x, 0x%x", boot_ctrl.magic[0], boot_ctrl.magic[1], boot_ctrl.magic[2], boot_ctrl.magic[3]);
+	debug(L"Avb magic 0x%x", boot_ctrl.magic);
 
-	magic = (CHAR8 *)AVB_AB_MAGIC;
-	if ((boot_ctrl.magic[0] == magic[0]) && \
-		(boot_ctrl.magic[1] == magic[1]) && \
-		(boot_ctrl.magic[2] == magic[2]) && \
-		(boot_ctrl.magic[3] == magic[3])) {
+	if (boot_ctrl.magic == BOOT_CTRL_MAGIC) {
 		debug(L"Avb magic is right");
 	} else {
 		error(L"A/B metadata is corrupted, re-initialize");
@@ -554,7 +545,6 @@ void slot_set_active_cached(const char *suffix)
 EFI_STATUS slot_init_use_misc(void)
 {
 	EFI_STATUS ret;
-	CHAR8 *magic;
 
 	if (!use_slot())
 		return EFI_SUCCESS;
@@ -571,15 +561,10 @@ EFI_STATUS slot_init_use_misc(void)
 		debug(L"No A/B metadata");
 		return EFI_SUCCESS;
 	}
-	debug(L"Avb magic 0x%x, 0x%x, 0x%x, 0x%x", boot_ctrl.magic[0], boot_ctrl.magic[1], boot_ctrl.magic[2], boot_ctrl.magic[3]);
+	debug(L"Avb magic 0x%x", boot_ctrl.magic);
 
-	magic = (CHAR8 *)AVB_AB_MAGIC;
-	if ((boot_ctrl.magic[0] == magic[0]) && \
-		(boot_ctrl.magic[1] == magic[1]) && \
-		(boot_ctrl.magic[2] == magic[2]) && \
-		(boot_ctrl.magic[3] == magic[3])) {
+	if (boot_ctrl.magic == BOOT_CTRL_MAGIC)
 		debug(L"Avb magic is right");
-	}
 
 	select_highest_priority_slot();
 	return EFI_SUCCESS;


### PR DESCRIPTION
Change bootloader control ab data structure to align with
android bootctrl 1.1

Signed-off-by: JianFeng,Zhou <jianfeng.zhou@intel.com>