### PR TITLE
slot-ab: enable boot when tries > 1

### DIFF
--- a/avb/libavb_ab/avb_ab_flow.c
+++ b/avb/libavb_ab/avb_ab_flow.c
@@ -152,12 +152,6 @@ static void slot_normalize(AvbABSlotData* slot) {
       /* We've exhausted all tries -> unbootable. */
       slot_set_unbootable(slot);
     }
-    if (slot->tries_remaining > 1 && slot->successful_boot) {
-      /* Illegal state - avb_ab_mark_slot_successful() will set
-       * tries_remaining to 1 when setting successful_boot.
-       */
-      slot_set_unbootable(slot);
-    }
   } else {
     slot_set_unbootable(slot);
   }


### PR DESCRIPTION
SetActiveBootSlot() of boot_control 1.1 always set slot
tries_remaining to 6.
Boot should be enabled in this case.

Signed-off-by: JianFeng,Zhou <jianfeng.zhou@intel.com>