### PR TITLE
Check the value of EpNum before accessing the EpHandles

### DIFF
--- a/libefiusb/device_mode/XdciDWC.c
+++ b/libefiusb/device_mode/XdciDWC.c
@@ -2824,6 +2824,11 @@ DwcXdciEpClearStall (
   //
   EpNum = DwcXdciGetPhysicalEpNum (EpInfo->EpNum, EpInfo->EpDir);
 
+  if (EpNum >= DWC_XDCI_MAX_ENDPOINTS * 2) {
+    DEBUG ((DEBUG_INFO, "DwcXdciEpClearStall: INVALID EpNum\n"));
+    return EFI_DEVICE_ERROR;
+  }
+
   //
   // Set Ep State Info
   //


### PR DESCRIPTION
EpNum shouldn't larger than (16 * 2), since basing on the usb
protocol, a USB device can only have up to 32 endpoints
(16 OUT and 16 IN).

Tracked-On: OAM-97425
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>