### PR TITLE
Kernelflinger: remove UI display and remove logs

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -92,7 +92,6 @@ ifneq ($(TARGET_BUILD_VARIANT),user)
 endif
 
 ifneq ($(strip $(KERNELFLINGER_USE_UI)),false)
-    KERNELFLINGER_CFLAGS += -DUSE_UI
 endif
 
 ifeq ($(KERNELFLINGER_OS_SECURE_BOOT),true)

--- a/avb/Android.mk
+++ b/avb/Android.mk
@@ -68,7 +68,6 @@ LOCAL_STATIC_LIBRARIES := \
 	libkernelflinger-$(TARGET_BUILD_VARIANT)
 
 ifneq ($(strip $(KERNELFLINGER_USE_UI)),false)
-    LOCAL_CFLAGS += -DUSE_UI
 endif
 
 LOCAL_SRC_FILES := \

--- a/kernelflinger.c
+++ b/kernelflinger.c
@@ -1103,7 +1103,7 @@ static VOID enter_fastboot_mode(UINT8 boot_state)
 
 	die();
 }
-static void bootloader_recover_mode(UINT8 boot_state)
+static void bootloader_recover_mode(UINT8 boot_state __unused)
 {
 	enum boot_target target;
 
@@ -1130,8 +1130,8 @@ static void bootloader_recover_mode(UINT8 boot_state)
 	die();
 }
 
-static VOID boot_error(enum ux_error_code error_code, UINT8 boot_state,
-			UINT8 *hash, UINTN hash_size)
+static VOID boot_error(enum ux_error_code error_code __unused, UINT8 boot_state,
+			UINT8 *hash __unused, UINTN hash_size __unused)
 {
 	BOOLEAN power_off = FALSE;
 	enum boot_target bt;


### PR DESCRIPTION
This can reduce 5 seconds boot delay in un-secure boot case

Tracked-On:
Signed-off-by: Chen Gang G <gang.g.chen@intel.com>