### PR TITLE
syscall was getting defined twice in Android S

### DIFF
--- a/libsslsupport/borningssl/sys/syscall.h
+++ b/libsslsupport/borningssl/sys/syscall.h
@@ -1,4 +1,5 @@
 /*
 function needed for compiling borningssl on Android O
 */
+#pragma once
 long syscall(long __number, ...){return 0;};


### PR DESCRIPTION
Making the definition pragma once.

Tracked-On: OAM-99873
Signed-off-by: Tanuj Tekriwal <tanuj.tekriwal@intel.com>